### PR TITLE
Fix schedule recording time bug

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/antonyho/crhk-recorder
 
 go 1.15
 
-require github.com/ushis/m3u v0.0.0-20150127162843-94396b784733
+require (
+	github.com/stretchr/testify v1.6.1
+	github.com/ushis/m3u v0.0.0-20150127162843-94396b784733
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,12 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/ushis/m3u v0.0.0-20150127162843-94396b784733 h1:m4zGEkIeft/gfUs469WS/gB6NT3RtkG8zQrOvCOzovE=
 github.com/ushis/m3u v0.0.0-20150127162843-94396b784733/go.mod h1:/w56gU05vgM74JSy2/xFy6tUQ9vJBMiciHNvyIEU1UY=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/pkg/stream/recorder/recorder.go
+++ b/pkg/stream/recorder/recorder.go
@@ -146,19 +146,17 @@ func (r Recorder) Schedule(startTime, endTime string) error {
 		return err
 	}
 	start = start.AddDate(thisYear, int(thisMonth)-1, thisDay-1)
-	if start.Before(time.Now()) {
-		timeDelay = 24 * time.Hour
-		start = start.Add(timeDelay)
-	}
 	end, err := time.Parse("15:04:05 -0700", endTime)
 	if err != nil {
 		return err
 	}
 	end = end.AddDate(thisYear, int(thisMonth)-1, thisDay-1)
-	if end.Before(start) {
+	if end.Before(start) { // To cover an overnight recording
 		end = end.Add(24 * time.Hour)
 	}
-	if timeDelay > 0 {
+	if start.Before(time.Now()) { // To cover start time already passed
+		timeDelay = 24 * time.Hour
+		start = start.Add(timeDelay)
 		end = end.Add(timeDelay)
 	}
 

--- a/pkg/stream/recorder/recorder_test.go
+++ b/pkg/stream/recorder/recorder_test.go
@@ -2,14 +2,15 @@ package recorder_test
 
 import (
 	"fmt"
-	"github.com/antonyho/crhk-recorder/pkg/stream/recorder"
 	"os"
 	"testing"
 	"time"
+
+	"github.com/antonyho/crhk-recorder/pkg/stream/recorder"
 )
 
 const (
-	channel = "881"
+	channel  = "881"
 	fileDest = "/tmp/881hd.aac"
 )
 
@@ -33,17 +34,18 @@ func TestRecorder_Record(t *testing.T) {
 	rcdr := recorder.NewRecorder(channel)
 	term := make(chan struct{})
 	go func() {
+		start := time.Now()
 		for {
 			select {
-			case <- term:
+			case <-term:
+				fmt.Println()
 				return
 			default:
-				start := time.Now()
 				fmt.Printf("\rElapsed: %v", time.Since(start))
 			}
 		}
 	}()
-	if err := rcdr.Record(time.Now().Add(2 * time.Second), time.Now().Add(2 * time.Minute)); err != nil {
+	if err := rcdr.Record(time.Now().Add(2*time.Second), time.Now().Add(10*time.Second)); err != nil {
 		t.Error(err)
 	}
 	term <- struct{}{}
@@ -53,8 +55,10 @@ func TestRecorder_Schedule(t *testing.T) {
 	terminate := make(chan bool)
 	performTest := func() {
 		rcdr := recorder.NewRecorder(channel)
-		startTime := time.Now().Add(5 * time.Second).Format("15:04:05 -0700")
-		endTime := time.Now().Add(30 * time.Second).Format("15:04:05 -0700")
+		tf := "15:04:05 -0700"
+		now := time.Now()
+		startTime := now.Add(5 * time.Second).Format(tf)
+		endTime := now.Add(30 * time.Second).Format(tf)
 		t.Logf("Start time: %v | End time: %v", startTime, endTime)
 		if err := rcdr.Schedule(startTime, endTime); err != nil {
 			t.Error(err)

--- a/pkg/stream/resolver/resolver.go
+++ b/pkg/stream/resolver/resolver.go
@@ -2,9 +2,10 @@ package resolver
 
 import (
 	"errors"
-	"github.com/ushis/m3u"
 	"io/ioutil"
 	"net/http"
+
+	"github.com/ushis/m3u"
 
 	"github.com/antonyho/crhk-recorder/pkg/stream/url"
 )


### PR DESCRIPTION
The scheduled recording time would be overadded,
if the recording is overnight and the start time has been missed.